### PR TITLE
Optimize for loops; fix retain cycles in lazy vars

### DIFF
--- a/Render/BaseComponentView.swift
+++ b/Render/BaseComponentView.swift
@@ -65,8 +65,7 @@ public class BaseComponentView: UIView, ComponentViewType {
     internal weak var _parentView: UIView?
     public var parentView: UIView? {
         get {
-            if let parent = self._parentView { return parent }
-            return self.superview
+            return self._parentView ?? self.superview
         }
         set {
             self._parentView = newValue

--- a/Render/ComponentView.swift
+++ b/Render/ComponentView.swift
@@ -72,7 +72,7 @@ extension ComponentViewType where Self: FlexboxComponentView {
             if !viewSet.contains(view) {
                 view.removeFromSuperview() //todo: put in a global reusable pool?
             } else {
-                for subview in view.subviews.filter({ return $0.hasFlexNode }) {
+                for subview in view.subviews where subview.hasFlexNode {
                     prune(subview)
                 }
             }

--- a/Render/Layout.swift
+++ b/Render/Layout.swift
@@ -538,11 +538,11 @@ public class Node {
         set { pointer.memory = newValue }
     }
     
-    lazy public var style: Style = {
+    lazy public var style: Style = { [unowned self] in
         return Style(node: self)
     }()
     
-    lazy public var layout: Layout = {
+    lazy public var layout: Layout = { [unowned self] in
         return Layout(node: self)
     }()
     

--- a/Render/ViewType.swift
+++ b/Render/ViewType.swift
@@ -46,12 +46,8 @@ extension FlexboxView where Self: UIView {
         }
         
         //adds the children as subviews
-        if let children = children {
-            for child in children {
-                self.addSubview(child)
-            }
-        }
-        
+        children?.forEach(self.addSubview)
+
         return self
     }
     
@@ -63,9 +59,7 @@ extension FlexboxView where Self: UIView {
             view.internalStore.configureClosure?()
             
             //calls it recursively on the subviews
-            for subview in view.subviews {
-                configure(subview)
-            }
+            view.subviews.forEach(configure)
         }
         
         //the view is configured before the layout
@@ -82,7 +76,7 @@ extension FlexboxView where Self: UIView {
         
         func postRender(view: UIView) {
             view.postRender()
-            for subview in view.subviews { postRender(subview) }
+            view.subviews.forEach(postRender)
         }
         
         let startTime = CFAbsoluteTimeGetCurrent()
@@ -184,7 +178,7 @@ extension UIView: FlexboxView {
     private func layout(bounds: CGSize = CGSize.undefined) {
 
         func prepare(view: UIView) {
-            for subview in view.subviews.filter({ return $0.hasFlexNode }) {
+            for subview in view.subviews where subview.hasFlexNode {
                 prepare(subview)
             }
         }
@@ -204,13 +198,13 @@ extension UIView: FlexboxView {
         
         //adds the children at this level
         var children = [Node]()
-        for subview in self.subviews.filter({ return $0.hasFlexNode }) {
+        for subview in self.subviews where subview.hasFlexNode {
             children.append(subview.flexNode)
         }
         self.flexNode.children = children
         
         //adds the childrens in the subiews
-        for subview in self.subviews.filter({ return $0.hasFlexNode }) {
+        for subview in self.subviews where subview.hasFlexNode {
             subview.recursivelyAddChildren()
         }
     }


### PR DESCRIPTION
1. Removes unnecessary filter step where possible allows to iterate array only once
2. Lazy vars have exact same capture behaviour as closures so unowned is [needed](https://github.com/raywenderlich/swift-style-guide/issues/88)
3. Tiny more swift-like loops as `children?.forEach(self.addSubview)`
