### PR TITLE
Display logo better on retina screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Render Logo](Doc/logo.png)
+# <img src="https://raw.githubusercontent.com/alexdrone/Render/master/Doc/logo.png" width="444" alt="Render" />
 
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)


### PR DESCRIPTION
The logo was upscaled. Now it is half its original size which makes it look good on retina screens.
