### PR TITLE
Fix incorrect paths for playgrounds

### DIFF
--- a/Playgrounds/RenderPlaygrounds.xcworkspace/contents.xcworkspacedata
+++ b/Playgrounds/RenderPlaygrounds.xcworkspace/contents.xcworkspacedata
@@ -5,15 +5,15 @@
       location = "group:../Render.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:/Users/alexusbergo/Desktop/swift/Render/Playgrounds/01 Flexbox Components.playground">
+      location = "group:01 Flexbox Components.playground">
    </FileRef>
    <FileRef
-      location = "group:/Users/alexusbergo/Desktop/swift/Render/Playgrounds/02 Vanilla Components.playground">
+      location = "group:02 Vanilla Components.playground">
    </FileRef>
    <FileRef
       location = "group:03 Component Styles.playground">
    </FileRef>
    <FileRef
-      location = "group:/Users/alexusbergo/Desktop/swift/Render/Playgrounds/04 Components embedded in Cells.playground">
+      location = "group:04 Components embedded in Cells.playground">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
I have noticed the paths for Playgrounds are hardcoded according the author local computer. This should fix it.
