### PR TITLE
Public NilComponent

### DIFF
--- a/Render/ComponentNode.swift
+++ b/Render/ComponentNode.swift
@@ -227,19 +227,18 @@ extension ComponentNodeType {
     }
 }
 
-/// Internally used to represent a nil component.
 /// It is always discarded when added.
-class NilComponent: ComponentNodeType {
-    var renderedView: UIView? = nil
-    var reuseIdentifier: String = ""
-    var children: [ComponentNodeType] = [NilComponent]()
-    var mounted: Bool = false
-    var index: Int = 0
-    var immutable: Bool = true
-    func render(bounds: CGSize) { }
-    func prepareForUnmount() { }
-    func prepareForMount() { }
-    func buildView(reusableView: UIView? = nil) { }
+public class NilComponent: ComponentNodeType {
+    public var renderedView: UIView? = nil
+    public var reuseIdentifier: String = ""
+    public var children: [ComponentNodeType] = [NilComponent]()
+    public var mounted: Bool = false
+    public var index: Int = 0
+    public var immutable: Bool = true
+    public func render(bounds: CGSize) { }
+    public func prepareForUnmount() { }
+    public func prepareForMount() { }
+    public func buildView(reusableView: UIView? = nil) { }
 }
 
 public func when(@autoclosure condition: () -> Bool, _ component: ComponentNodeType) -> ComponentNodeType {

--- a/Render/ComponentNode.swift
+++ b/Render/ComponentNode.swift
@@ -232,7 +232,7 @@ public class NilComponent: ComponentNodeType {
     public var renderedView: UIView? = nil
     public var reuseIdentifier: String = ""
     public var children: [ComponentNodeType] = [NilComponent]()
-    public var mounted: Bool = false
+    public internal(set) var mounted: Bool = false
     public var index: Int = 0
     public var immutable: Bool = true
     public func init() { }

--- a/Render/ComponentNode.swift
+++ b/Render/ComponentNode.swift
@@ -228,7 +228,7 @@ extension ComponentNodeType {
 }
 
 /// It is always discarded when added.
-public class NilComponent: ComponentNodeType {
+public final class NilComponent: ComponentNodeType {
     public var renderedView: UIView? = nil
     public var reuseIdentifier: String = ""
     public var children: [ComponentNodeType] = [NilComponent]()

--- a/Render/ComponentNode.swift
+++ b/Render/ComponentNode.swift
@@ -235,6 +235,7 @@ public class NilComponent: ComponentNodeType {
     public var mounted: Bool = false
     public var index: Int = 0
     public var immutable: Bool = true
+    public func init() { }
     public func render(bounds: CGSize) { }
     public func prepareForUnmount() { }
     public func prepareForMount() { }


### PR DESCRIPTION
**Why?**
Well if you need to represent "nothing" for e.g. .None case of

```
enum Icon { 
  case Some(String) 
  case None
} 
```

You can simply do:

```
extension Icon {
  var componentNode: ComponentNodeType {
    switch self {
      case .None:
        return ComponentNode<UIImageView>().confi......
      case .None:
        return NilComponent()
    }
  }
}
```
